### PR TITLE
Guess query format suggestions

### DIFF
--- a/nail/Cargo.toml
+++ b/nail/Cargo.toml
@@ -17,8 +17,12 @@ clap = { version = "4.0.32", features = ["derive"] }
 libnail = { path = "../libnail", version = "0.1.0" }
 anyhow = "1.0.66"
 thiserror = "1.0.37"
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.93"
 rayon = "1.7.0"
 thread_local = "1.1.7"
 indicatif = "0.17.8"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/nail/src/pipeline/search.rs
+++ b/nail/src/pipeline/search.rs
@@ -3,7 +3,8 @@ use crate::cli::CommonArgs;
 use crate::database::{Database, ProfileCollection, SequenceCollection};
 use crate::extension_traits::PathBufExt;
 use crate::pipeline::{
-    seed, AlignArgs, AlignOutputArgs, MmseqsArgs, NailArgs, PrepDirArgs, SeedArgs,
+    seed, AlignArgs, AlignOutputArgs, MmseqsArgs, NailArgs, PrepDirArgs,
+    SeedArgs,
 };
 use anyhow::Context;
 use clap::Args;
@@ -13,8 +14,8 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use super::{
-    align, map_p7_to_mmseqs_profiles, DefaultAlignStep, DefaultCloudSearchStep, DefaultSeedStep,
-    Output, Pipeline,
+    align, map_p7_to_mmseqs_profiles, DefaultAlignStep,
+    DefaultCloudSearchStep, DefaultSeedStep, Output, Pipeline,
 };
 
 #[derive(Debug, Args)]
@@ -91,6 +92,7 @@ pub fn search(args: &SearchArgs) -> anyhow::Result<()> {
                 Sequence::amino_from_fasta(&align_args.query_path)
                     .context("failed to read query fasta")?,
             );
+
             Box::new(queries)
         }
         FileFormat::Hmm => {
@@ -104,14 +106,17 @@ pub fn search(args: &SearchArgs) -> anyhow::Result<()> {
             Box::new(queries)
         }
         FileFormat::Stockholm => {
-            let profiles = parse_hmms_from_p7hmm_file(args.prep_dir.prep_query_hmm_path())
-                .context("failed to read query hmm")?
-                .iter()
-                .map(Profile::new)
-                .collect();
+            let profiles = parse_hmms_from_p7hmm_file(
+                args.prep_dir.prep_query_hmm_path(),
+            )
+            .context("failed to read query hmm")?
+            .iter()
+            .map(Profile::new)
+            .collect();
             let queries = ProfileCollection::new(profiles);
 
-            let p7_to_mmseqs_map = map_p7_to_mmseqs_profiles(&queries, &seed_args)?;
+            let p7_to_mmseqs_map =
+                map_p7_to_mmseqs_profiles(&queries, &seed_args)?;
 
             seeds.iter_mut().for_each(|(a, b)| {
                 let map = p7_to_mmseqs_map.get(a).unwrap();


### PR DESCRIPTION
- Lose UnrecognizedFileFormatError since it's never used anywhere, make error simpler
- Use File::open().map_err() to give OS error information in failure message
- Use regex to check header line instead of array access to possibly empty header line (from empty file)
- Use anyhow::{bail, anyhow} to create errors
- Add tests with input files in "tests/inputs" for all file formats plus empty file to check edge cases
- Curious if PathBuf is overkill for "query_path," maybe easier to use a string since no Path functions are invoked?