### PR TITLE
Add --acc option to report profile accessions in output

### DIFF
--- a/fixtures/a.seeds
+++ b/fixtures/a.seeds
@@ -1,411 +1,410 @@
-AAA	A1URA3|reviewed|ATP-dependent	1	130	192	324	125
-AAA	A0PXM8|reviewed|ATP-dependent	1	130	204	336	124
-AAA	A0L4S0|reviewed|ATP-dependent	1	130	190	322	123
-AAA	A4G0S4|reviewed|Proteasome-activating	1	129	185	316	121
-AAA	A1AT11|reviewed|ATP-dependent	1	130	210	342	121
-AAA	A0A061IR73|reviewed|Peroxisomal	1	130	740	871	121
-AAA	A3CV35|reviewed|Proteasome-activating	1	130	190	322	120
-AAA	A0LR74|reviewed|ATP-dependent	1	130	215	348	118
-AAA	A1TZE0|reviewed|ATP-dependent	1	130	222	354	118
-AAA	A0LN68|reviewed|ATP-dependent	1	130	223	355	117
-AAA	A2ZVG7|reviewed|ATP-dependent	1	130	364	492	113
-AAA	A2SHH9|reviewed|ATP-dependent	1	130	194	327	111
-AAA	A2VDN5|reviewed|Spastin|taxID:9913	1	129	376	504	111
-AAA	A4IHT0|reviewed|Fidgetin-like	1	130	419	548	110
-AAA	A0JMA9|reviewed|Katanin	1	130	294	425	105
-AAA	A0A7N9VSG0|reviewed|ATPase	1	130	230	362	102
-AAA	A1SK07|reviewed|Proteasome-associated	1	130	266	412	96
-AAA	A0LU46|reviewed|Proteasome-associated	1	130	264	411	95
-AAA	A0PQT9|reviewed|Proteasome-associated	1	130	289	438	94
-AAA	A0QFB2|reviewed|Proteasome-associated	1	130	289	438	94
-AAA	A1KKF8|reviewed|Proteasome-associated	1	130	289	438	94
-AAA	A0QZ54|reviewed|Proteasome-associated	1	130	293	442	94
-AAA	A1TAQ3|reviewed|Proteasome-associated	1	130	295	444	94
-AAA	A1UHT0|reviewed|Proteasome-associated	1	130	295	444	94
-AAA	A3Q196|reviewed|Proteasome-associated	1	130	295	444	94
-AAA	A4FBX6|reviewed|Proteasome-associated	1	130	277	426	94
-AAA	A1A0U4|reviewed|AAA	1	130	233	374	93
-AAA	A0JWY3|reviewed|Proteasome-associated	1	129	275	421	93
-AAA	A1R6Q4|reviewed|Proteasome-associated	1	129	283	429	93
-AAA	A2XUN8|reviewed|Pachytene	1	130	209	354	74
-AAA	A3LUF7|reviewed|Lon	1	119	663	800	72
-AAA	A0RJ87|reviewed|Lon	1	126	370	507	71
-AAA	A0LEE9|reviewed|Lon	1	126	360	497	70
-AAA	A0QNI9|reviewed|ESX-1	1	130	331	465	68
-AAA	A3M072|reviewed|Lon	1	126	554	691	68
-AAA	A0A8I6AGW3|reviewed|Fidgetin-like	1	129	427	550	67
-AAA	A0L516|reviewed|Lon	1	130	391	532	65
-AAA	A2RAF6|reviewed|Lon	1	126	480	618	65
-AAA	A2QCJ2|reviewed|Lon	1	124	605	740	64
-AAA	A0LG61|reviewed|Lon	1	126	358	495	63
-AAA	A2YQ56|reviewed|Lon	1	126	464	601	63
-AAA	A0QQ38|reviewed|ESX-3	1	130	361	493	58
-AAA	A2BL93|reviewed|Replication	2	74	48	120	54
-AAA	A3DNV8|reviewed|Replication	2	112	47	144	53
-AAA	A4FZL6|reviewed|Replication	1	122	42	148	52
-AAA	A2T308|reviewed|Protein	1	129	1651	1794	51
-AAA	A3CTR4|reviewed|Replication	1	74	39	112	51
-AAA	A3MS27|reviewed|Replication	1	119	59	163	50
-AAA	A2SQR6|reviewed|Replication	1	87	39	125	49
-AAA	A2SQT3|reviewed|Replication	1	130	42	161	48
-AAA	A1RWU6|reviewed|Replication	2	124	51	161	48
-AAA	A3MS28|reviewed|Replication	1	130	40	159	48
-AAA	A0B6D7|reviewed|Replication	1	119	43	148	47
-AAA	A4FZ74|reviewed|Replication	1	130	39	158	47
-AAA	A1RSA2|reviewed|Replication	1	130	40	159	46
-AAA	A3DNV9|reviewed|Replication	1	130	47	166	45
-AAA	A1RSA3|reviewed|Replication	1	111	59	157	45
-AAA	A1RV38|reviewed|Replication	1	118	40	148	44
-AAA	A0R574|reviewed|ATP-dependent	3	76	214	299	44
-AAA	A3CUX9|reviewed|Replication	1	130	42	161	42
-AAA	A1RWU7|reviewed|Replication	1	130	40	159	40
-AAA	A1S2P4|reviewed|ATP-dependent	1	89	53	136	40
-AAA	A0L1J9|reviewed|ATP-dependent	1	89	53	136	38
-AAA	A3N333|reviewed|ATP-dependent	1	89	52	135	37
-AAA	A3Q9U8|reviewed|ATP-dependent	1	89	53	136	37
-AAA	A1RP57|reviewed|ATP-dependent	1	89	53	136	37
-AAA	A3D9C6|reviewed|ATP-dependent	1	89	53	136	37
-AAA	A1AIA6|reviewed|ATP-dependent	1	89	53	136	37
-AAA	A1UU56|reviewed|ATP-dependent	1	46	54	100	37
-AAA	A0KQI8|reviewed|ATP-dependent	1	53	53	106	36
-AAA	A1JI08|reviewed|ATP-dependent	1	53	53	106	36
-AAA	A1SQW3|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A0Q6L9|reviewed|ATP-dependent	1	57	54	112	36
-AAA	A4IY57|reviewed|ATP-dependent	1	57	54	112	36
-AAA	A0KBG3|reviewed|ATP-dependent	1	91	53	138	36
-AAA	A1WRK1|reviewed|ATP-dependent	1	57	53	107	36
-AAA	A1K2I6|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A1V7K6|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A2S869|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A3MRR3|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A3N4H2|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A3NQ62|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A0L3K1|reviewed|ATP-dependent	1	46	53	99	36
-AAA	A1TKC1|reviewed|ATP-dependent	1	89	53	136	35
-AAA	A1TYU5|reviewed|ATP-dependent	1	46	53	99	35
-AAA	A1WC16|reviewed|ATP-dependent	1	89	53	136	35
-AAA	A4IM89|reviewed|ATP-dependent	1	46	54	100	35
-AAA	A4J5Z5|reviewed|ATP-dependent	1	46	53	99	35
-AAA	A1VZ21|reviewed|ATP-dependent	1	36	52	87	35
-AAA	A1VDW3|reviewed|ATP-dependent	1	91	53	138	35
-AAA	A0A379|reviewed|Protein	50	118	1725	1789	34
-AAA	A2SPC3|reviewed|ORC1-type	1	130	63	223	34
-AAA	A0AI82|reviewed|ATP-dependent	1	46	59	105	34
-AAA	A1B5T0|reviewed|ATP-dependent	1	46	53	99	33
-AAA	A3PG35|reviewed|ATP-dependent	1	46	53	99	33
-AAA	A4GGE1|reviewed|Protein	1	118	1625	1781	32
-AAA	A4GYV4|reviewed|Protein	50	118	1729	1793	31
-AAA	A1XGT0|reviewed|Protein	50	118	1729	1793	31
-AAA	A0ZZ78|reviewed|Protein	50	118	1740	1804	30
-AAA	A1XFZ9|reviewed|Protein	50	118	1696	1760	30
-7tm_3	P41180|reviewed|Extracellular	1	249	606	854	230
-7tm_3	O62714|reviewed|Extracellular	1	249	606	854	229
-7tm_3	P35384|reviewed|Extracellular	1	249	607	855	228
-7tm_3	P48442|reviewed|Extracellular	1	249	606	854	228
-7tm_3	E9Q6I0|reviewed|Vomeronasal	1	250	579	828	214
-7tm_3	Q6TAC4|reviewed|Vomeronasal	1	250	587	836	211
-7tm_3	P31422|reviewed|Metabotropic	1	250	570	821	209
-7tm_3	Q14416|reviewed|Metabotropic	1	250	561	812	205
-7tm_3	Q14BI2|reviewed|Metabotropic	1	250	561	812	205
-7tm_3	P31421|reviewed|Metabotropic	1	250	561	812	205
-7tm_3	Q1ZZH1|reviewed|Metabotropic	1	250	570	821	205
-7tm_3	Q14832|reviewed|Metabotropic	1	250	570	821	204
-7tm_3	Q5RAL3|reviewed|Metabotropic	1	250	570	821	204
-7tm_3	Q70VB1|reviewed|G-protein	1	250	587	834	203
-7tm_3	Q8K4Z6|reviewed|G-protein	1	250	587	834	202
-7tm_3	Q5U9X3|reviewed|G-protein	2	250	560	804	200
-7tm_3	P91685|reviewed|Metabotropic	1	250	620	869	198
-7tm_3	P23385|reviewed|Metabotropic	1	250	586	833	198
-7tm_3	P97772|reviewed|Metabotropic	1	250	586	833	198
-7tm_3	Q5T6X5|reviewed|G-protein	1	250	587	832	197
-7tm_3	Q13255|reviewed|Metabotropic	1	250	586	833	197
-7tm_3	P31424|reviewed|Metabotropic	1	250	572	819	194
-7tm_3	Q3UVX5|reviewed|Metabotropic	1	250	572	819	194
-7tm_3	P41594|reviewed|Metabotropic	1	250	573	820	194
-7tm_3	Q09630|reviewed|Probable	1	250	675	922	192
-7tm_3	O70410|reviewed|Vomeronasal	1	250	614	862	188
-7tm_3	O00222|reviewed|Metabotropic	1	250	577	836	185
-7tm_3	P47743|reviewed|Metabotropic	1	250	577	836	185
-7tm_3	P70579|reviewed|Metabotropic	1	250	577	836	185
-7tm_3	P35400|reviewed|Metabotropic	1	250	584	843	185
-7tm_3	Q14831|reviewed|Metabotropic	1	250	584	843	185
-7tm_3	Q68ED2|reviewed|Metabotropic	1	250	584	843	185
-7tm_3	Q5RDQ8|reviewed|Metabotropic	1	250	584	843	185
-7tm_3	O15303|reviewed|Metabotropic	1	250	579	838	183
-7tm_3	Q863I4|reviewed|Metabotropic	1	250	570	829	181
-7tm_3	P35349|reviewed|Metabotropic	1	250	573	832	181
-7tm_3	Q68EF4|reviewed|Metabotropic	1	250	581	840	181
-7tm_3	P31423|reviewed|Metabotropic	1	250	581	840	181
-7tm_3	Q1ZZH0|reviewed|Metabotropic	1	250	581	840	180
-7tm_3	Q5NCH9|reviewed|Metabotropic	1	250	573	832	180
-7tm_3	Q14833|reviewed|Metabotropic	1	250	581	840	180
-7tm_3	E1BPQ3|reviewed|G-protein	5	250	565	801	171
-7tm_3	O75899|reviewed|Gamma-aminobutyric	2	250	476	742	166
-7tm_3	O88871|reviewed|Gamma-aminobutyric	2	250	475	741	165
-7tm_3	Q80T41|reviewed|Gamma-aminobutyric	2	250	475	741	165
-7tm_3	Q54SW3|reviewed|Metabotropic	2	248	364	614	158
-7tm_3	A3QP08|reviewed|Taste	1	250	554	805	156
-7tm_3	Q8TE23|reviewed|Taste	1	250	559	810	156
-7tm_3	A3QNZ8|reviewed|Taste	1	250	559	810	156
-7tm_3	A3QNZ9|reviewed|Taste	1	250	559	810	156
-7tm_3	Q49HI0|reviewed|Taste	1	250	558	807	156
-7tm_3	A3QP01|reviewed|Taste	1	250	559	810	154
-7tm_3	A3QP07|reviewed|Taste	1	250	559	810	154
-7tm_3	Q75JT4|reviewed|Metabotropic	1	248	373	624	154
-7tm_3	Q925I4|reviewed|Taste	1	250	563	814	153
-7tm_3	A3QP00|reviewed|Taste	1	250	559	810	153
-7tm_3	Q55AP1|reviewed|Metabotropic	2	248	379	629	149
-7tm_3	Q86HH3|reviewed|Metabotropic	2	248	377	627	149
-7tm_3	G5ECB2|reviewed|Gamma-aminobutyric	3	250	436	698	149
-7tm_3	Q54ET0|reviewed|Metabotropic	3	250	431	676	147
-7tm_3	A3QP09|reviewed|Taste	1	250	554	805	147
-7tm_3	Q7RTX1|reviewed|Taste	1	250	560	810	146
-7tm_3	Q54L53|reviewed|Metabotropic	4	250	386	636	145
-7tm_3	Q54LG8|reviewed|Metabotropic	1	250	377	630	144
-7tm_3	Q54SH7|reviewed|Metabotropic	3	250	386	637	143
-7tm_3	Q54SH8|reviewed|Metabotropic	3	250	387	638	138
-7tm_3	Q75JP4|reviewed|Metabotropic	2	250	385	637	138
-7tm_3	Q923K1|reviewed|Taste	1	250	567	817	136
-7tm_3	Q1ZXQ7|reviewed|Metabotropic	3	250	378	629	135
-7tm_3	Q55AP3|reviewed|Metabotropic	2	248	388	645	134
-7tm_3	Q49HH9|reviewed|Taste	1	250	560	810	134
-7tm_3	Q717C2|reviewed|Taste	1	250	562	812	134
-7tm_3	Q717C1|reviewed|Taste	1	250	562	812	134
-7tm_3	Q7RTX0|reviewed|Taste	1	250	562	812	133
-7tm_3	Q54F54|reviewed|Metabotropic	1	250	689	941	130
-7tm_3	E9PY61|reviewed|G-protein	6	250	379	629	129
-7tm_3	Q925D8|reviewed|Taste	1	250	567	817	128
-7tm_3	Q49KI5|reviewed|Taste	1	250	565	815	128
-7tm_3	Q5T848|reviewed|Metabotropic	7	250	416	665	124
-7tm_3	Q6PRD1|reviewed|Probable	7	250	380	629	124
-7tm_3	D4A6L0|reviewed|Metabotropic	7	250	416	665	124
-7tm_3	E1BBQ2|reviewed|Metabotropic	7	250	416	665	124
-7tm_3	Q8C419|reviewed|Metabotropic	7	250	416	665	123
-7tm_3	Q8K451|reviewed|Probable	10	250	52	310	120
-7tm_3	Q54QG7|reviewed|Metabotropic	3	250	393	641	120
-7tm_3	Q6PCP7|reviewed|Probable	10	250	52	310	120
-7tm_3	Q8NFN8|reviewed|Probable	2	250	44	310	117
-7tm_3	Q54K11|reviewed|Metabotropic	4	250	1145	1394	113
-7tm_3	H2L0Q3|reviewed|Gamma-aminobutyric	1	250	442	763	111
-7tm_3	Q923Z0|reviewed|G-protein	1	250	49	290	106
-7tm_3	Q8BHL4|reviewed|Retinoic	1	250	23	265	96
-7tm_3	Q8K3J9|reviewed|G-protein	1	250	42	297	95
-7tm_3	Q54U89|reviewed|Metabotropic	10	248	368	616	95
-7tm_3	Q2YDG0|reviewed|G-protein	1	250	43	299	94
-7tm_3	Q3KRC4|reviewed|G-protein	1	250	42	297	94
-7tm_3	Q8NFJ5|reviewed|Retinoic	1	250	21	263	87
-7tm_3	Q24738|reviewed|Protein	5	250	525	772	76
-7tm_3	P22815|reviewed|Protein	5	250	528	775	76
-7tm_3	P34352|reviewed|Uncharacterized	9	238	691	904	72
-7tm_3	O02213|reviewed|Tyramine	10	185	61	237	29
-7tm_3	F1R332|reviewed|Galanin	3	212	14	244	28
-7tm_3	A6QLE7|reviewed|G-protein	5	183	43	223	27
-7tm_3	O08726|reviewed|Galanin	3	184	21	208	26
-7tm_3	E7F7V7|reviewed|Galanin	2	221	21	264	26
-7tm_3	O08892|reviewed|5-hydroxytryptamine	6	178	46	218	24
-7tm_3	G5EDK5|reviewed|Cadherin	23	184	2206	2378	24
-7tm_3	O08675|reviewed|Proteinase-activated	49	244	139	348	24
-7tm_3	O01670|reviewed|Octopamine	6	186	83	266	24
-7tm_2	P97751|reviewed|Vasoactive	1	249	140	385	246
-7tm_2	P30083|reviewed|Vasoactive	1	249	140	385	246
-7tm_2	P32241|reviewed|Vasoactive	1	249	139	383	243
-7tm_2	Q28992|reviewed|Vasoactive	1	249	140	384	242
-7tm_2	P41586|reviewed|Pituitary	1	249	150	395	242
-7tm_2	O46502|reviewed|Secretin	3	249	137	379	236
-7tm_2	P23811|reviewed|Secretin	3	249	141	383	235
-7tm_2	P47872|reviewed|Secretin	3	249	141	383	231
-7tm_2	P70205|reviewed|Pituitary	1	249	150	423	227
-7tm_2	Q29627|reviewed|Pituitary	1	249	167	440	227
-7tm_2	P41587|reviewed|Vasoactive	1	249	123	370	222
-7tm_2	P32215|reviewed|Pituitary	1	249	149	450	215
-7tm_2	P50133|reviewed|Parathyroid	1	249	180	449	214
-7tm_2	P35000|reviewed|Vasoactive	1	249	122	369	213
-7tm_2	P41588|reviewed|Vasoactive	1	249	122	369	213
-7tm_2	Q1LZF7|reviewed|Parathyroid	1	249	184	453	213
-7tm_2	P25107|reviewed|Parathyroid	1	249	181	448	212
-7tm_2	Q03431|reviewed|Parathyroid	1	249	184	454	211
-7tm_2	O95490|reviewed|Adhesion	4	249	847	1079	208
-7tm_2	P25961|reviewed|Parathyroid	1	249	184	454	207
-7tm_2	P41593|reviewed|Parathyroid	1	249	184	454	207
-7tm_2	P49190|reviewed|Parathyroid	1	249	141	408	206
-7tm_2	P32082|reviewed|Growth	1	249	126	371	206
-7tm_2	P48960|reviewed|Adhesion	3	249	546	781	206
-7tm_2	Q02643|reviewed|Growth	1	249	126	371	205
-7tm_2	O35659|reviewed|Glucagon-like	3	249	143	397	203
-7tm_2	P32301|reviewed|Glucagon-like	3	249	143	397	202
-7tm_2	O97827|reviewed|Adhesion	4	249	945	1186	202
-7tm_2	P34999|reviewed|Growth	1	249	126	371	201
-7tm_2	O08893|reviewed|Calcitonin	1	249	145	386	200
-7tm_2	O97831|reviewed|Adhesion	4	249	859	1091	200
-7tm_2	O88917|reviewed|Adhesion	4	249	859	1091	200
-7tm_2	P43219|reviewed|Gastric	3	249	133	384	199
-7tm_2	O94910|reviewed|Adhesion	4	249	860	1092	199
-7tm_2	Q0P543|reviewed|Gastric	3	249	132	383	199
-7tm_2	P48546|reviewed|Gastric	3	249	136	387	199
-7tm_2	P43220|reviewed|Glucagon-like	4	249	144	397	199
-7tm_2	P30988|reviewed|Calcitonin	1	249	145	386	199
-7tm_2	P30082|reviewed|Glucagon	1	249	139	396	199
-7tm_2	P70555|reviewed|Parathyroid	1	249	139	405	198
-7tm_2	O95838|reviewed|Glucagon-like	4	249	178	431	198
-7tm_2	O97817|reviewed|Adhesion	4	249	851	1098	197
-7tm_2	P43218|reviewed|Gastric	3	249	133	384	196
-7tm_2	P35347|reviewed|Corticotropin-releasing	6	249	121	358	196
-7tm_2	P34998|reviewed|Corticotropin-releasing	1	249	116	358	195
-7tm_2	P35353|reviewed|Corticotropin-releasing	1	249	116	358	195
-7tm_2	P47871|reviewed|Glucagon	1	249	138	395	195
-7tm_2	Q14246|reviewed|Adhesion	3	249	601	839	195
-7tm_2	P79222|reviewed|Calcitonin	1	249	145	386	194
-7tm_2	Q0P4Y4|reviewed|Calcitonin	1	249	148	389	194
-7tm_2	O62772|reviewed|Corticotropin-releasing	6	249	121	358	193
-7tm_2	Q16602|reviewed|Calcitonin	1	249	138	379	192
-7tm_2	A0A2Z2U4G9|reviewed|Glucagon	1	249	138	395	192
-7tm_2	O88923|reviewed|Adhesion	4	249	851	1107	192
-7tm_2	O42602|reviewed|Corticotropin-releasing	6	249	121	358	189
-7tm_2	A6QP74|reviewed|Calcitonin	1	249	139	380	189
-7tm_2	P32214|reviewed|Calcitonin	1	249	145	423	188
-7tm_2	Q02644|reviewed|Growth	1	249	126	412	185
-7tm_2	P47866|reviewed|Corticotropin-releasing	6	249	118	354	184
-7tm_2	O42603|reviewed|Corticotropin-releasing	6	249	120	356	183
-7tm_2	Q13324|reviewed|Corticotropin-releasing	6	249	118	354	181
-7tm_2	P25117|reviewed|Calcitonin	4	249	149	403	178
-7tm_2	O35161|reviewed|Cadherin	4	249	2483	2711	177
-7tm_2	G5ECX0|reviewed|Latrophilin-like	1	249	894	1128	171
-7tm_2	O88278|reviewed|Cadherin	4	248	2537	2764	169
-7tm_2	A6QLU6|reviewed|Adhesion	4	249	594	829	168
-7tm_2	Q2Q421|reviewed|Adhesion	4	249	543	780	167
-7tm_2	O14514|reviewed|Adhesion	1	249	944	1179	162
-7tm_2	C0HL12|reviewed|Adhesion	6	249	945	1175	161
-7tm_2	Q3UHD1|reviewed|Adhesion	6	249	949	1179	161
-7tm_2	Q09460|reviewed|Calcitonin	1	249	164	424	160
-7tm_2	Q2Q426|reviewed|Adhesion	4	249	529	766	157
-7tm_2	P35464|reviewed|Diuretic	7	248	89	338	156
-7tm_2	Q16983|reviewed|Diuretic	10	248	139	380	156
-7tm_2	O60241|reviewed|Adhesion	3	249	931	1197	149
-7tm_2	G5EDW2|reviewed|Latrophilin-like	4	249	551	787	144
-7tm_2	O60242|reviewed|Adhesion	6	249	879	1142	144
-7tm_2	B7ZCC9|reviewed|Adhesion	4	249	2693	2931	139
-7tm_2	C6KFA3|reviewed|Adhesion	4	249	851	1098	135
-7tm_2	P30650|reviewed|G-protein	12	225	230	446	109
-7tm_2	G5E8Q8|reviewed|Adhesion	4	249	1014	1263	104
-7tm_2	Q3V3Z3|reviewed|Adhesion	4	249	244	494	101
-7tm_2	E9Q4J9|reviewed|Adhesion	4	246	381	624	99
-7tm_2	D4A3T6|reviewed|Adhesion	4	246	381	624	98
-7tm_2	Q50DM6|reviewed|Adhesion	4	249	403	647	94
-7tm_2	Q50DM5|reviewed|Adhesion	4	249	403	647	91
-7tm_2	B3MFV7|reviewed|Latrophilin	3	248	763	1010	73
-7tm_2	B4KMZ1|reviewed|Latrophilin	3	248	755	1002	73
-7tm_2	B4P3A0|reviewed|Latrophilin	3	248	765	1012	72
-7tm_2	B4HS00|reviewed|Latrophilin	3	248	751	998	71
-7tm_2	A1Z7G7|reviewed|Latrophilin	3	248	751	998	71
-7tm_2	B3N8M1|reviewed|Latrophilin	3	248	765	1012	71
-7tm_2	B4GD14|reviewed|Latrophilin	3	248	763	1010	71
-7tm_2	Q292N4|reviewed|Latrophilin	3	248	772	1019	71
-7tm_2	B4LNA8|reviewed|Latrophilin	3	245	769	1010	71
-7tm_2	P83120|reviewed|G-protein	9	249	219	469	68
-7tm_2	O97148|reviewed|G-protein	9	249	219	469	67
-7tm_2	E7FBY6|reviewed|Adhesion	6	186	743	925	53
-7tm_2	G5EDK5|reviewed|Cadherin	17	224	2237	2423	47
-7tm_2	E7F7V7|reviewed|Galanin	77	218	100	251	27
-7tm_2	O02465|reviewed|Opsin-2|taxID:7130	21	86	73	134	26
-7tm_2	F7EQ49|reviewed|G-protein	8	209	55	267	25
-7tm_1	O08858|reviewed|Somatostatin	1	259	54	302	189
-7tm_1	F1MV99|reviewed|Somatostatin	1	259	58	305	187
-7tm_1	A0T2N3|reviewed|Apelin	1	259	51	315	182
-7tm_1	O02824|reviewed|Alpha-1A	1	259	43	325	176
-7tm_1	C3ZQF9|reviewed|QRFP-like	1	259	64	325	175
-7tm_1	O02666|reviewed|Alpha-1D	1	259	118	406	174
-7tm_1	F1R332|reviewed|Galanin	1	259	35	285	170
-7tm_1	O02813|reviewed|Neuropeptide	1	258	56	317	170
-7tm_1	O08892|reviewed|5-hydroxytryptamine	2	259	66	367	169
-7tm_1	O08556|reviewed|C-C	1	259	49	298	169
-7tm_1	O08565|reviewed|C-X-C	1	259	52	298	168
-7tm_1	O02835|reviewed|Neuropeptide	1	258	57	318	168
-7tm_1	E7F7V7|reviewed|Galanin	1	259	43	293	166
-7tm_1	G3M4F8|reviewed|Octopamine	1	259	54	335	165
-7tm_1	D4A7K7|reviewed|G-protein	1	259	44	303	162
-7tm_1	O08726|reviewed|Galanin	1	259	42	291	161
-7tm_1	O08786|reviewed|Cholecystokinin	1	259	58	377	161
-7tm_1	A6QNL7|reviewed|CX3C	1	259	49	293	160
-7tm_1	E9QJ73|reviewed|C-X-C	1	259	60	317	158
-7tm_1	O02662|reviewed|Beta-3	1	259	54	345	158
-7tm_1	A7YY44|reviewed|Proteinase-activated	2	259	122	372	158
-7tm_1	F5HF62|reviewed|Envelope	1	259	50	290	156
-7tm_1	O08890|reviewed|5-hydroxytryptamine	2	259	41	346	155
-7tm_1	B2ZI34|reviewed|Neuromedin-B	1	258	60	322	155
-7tm_1	O08725|reviewed|Growth	1	259	59	320	153
-7tm_1	O02836|reviewed|Neuropeptide	1	259	68	325	152
-7tm_1	O13076|reviewed|Adenosine	1	259	22	289	151
-7tm_1	A5A4K9|reviewed|Growth	1	259	60	322	151
-7tm_1	A5A4L1|reviewed|Growth	1	259	60	322	150
-7tm_1	O00254|reviewed|Proteinase-activated	2	259	112	357	150
-7tm_1	A5PLE7|reviewed|G-protein	1	259	44	302	149
-7tm_1	O02213|reviewed|Tyramine	1	259	74	422	148
-7tm_1	G4WMX4|reviewed|RYamide	1	259	47	309	148
-7tm_1	O00590|reviewed|Atypical	1	259	63	311	147
-7tm_1	B1PHQ8|reviewed|Chemerin-like	1	259	53	311	145
-7tm_1	O00574|reviewed|C-X-C	1	259	48	287	144
-7tm_1	A1ZAX0|reviewed|Neuropeptide	1	258	98	364	144
-7tm_1	O09027|reviewed|Atypical	1	259	62	311	144
-7tm_1	B5X337|reviewed|G-protein	1	259	54	312	143
-7tm_1	O08707|reviewed|Atypical	1	259	62	310	143
-7tm_1	O02667|reviewed|Adenosine	1	259	30	282	143
-7tm_1	B9VR26|reviewed|Chemerin-like	1	259	52	310	143
-7tm_1	O08675|reviewed|Proteinase-activated	2	259	111	356	143
-7tm_1	O02464|reviewed|Opsin-1|taxID:7130	1	259	71	332	143
-7tm_1	B0UXR0|reviewed|G-protein	1	259	41	300	141
-7tm_1	F5HDK1|reviewed|Envelope	2	259	50	295	139
-7tm_1	O00155|reviewed|Probable	1	259	56	306	138
-7tm_1	B3G515|reviewed|G-protein	1	259	61	308	137
-7tm_1	A4FUQ5|reviewed|Formyl	1	259	43	296	134
-7tm_1	A0A287A2K5|reviewed|Gastrin/cholecystokinin	1	259	69	394	134
-7tm_1	O08790|reviewed|Formyl	1	259	43	301	133
-7tm_1	O01668|reviewed|Opsin	1	259	64	326	133
-7tm_1	B0F9W3|reviewed|G-protein	1	259	61	308	132
-7tm_1	F7EQ49|reviewed|G-protein	1	259	76	323	131
-7tm_1	E7EM37|reviewed|Dopamine	1	194	54	238	129
-7tm_1	O00270|reviewed|12-(S)-hydroxy-5,8,10,14-eicosatetraenoic	1	259	31	281	128
-7tm_1	B0V1P1|reviewed|Melanocortin	1	259	58	299	127
-7tm_1	A0A2L0VBG2|reviewed|Adipokinetic	1	259	123	392	127
-7tm_1	O01670|reviewed|Octopamine	1	199	98	293	126
-7tm_1	O08878|reviewed|G-protein	1	259	76	323	126
-7tm_1	O02664|reviewed|D(1A)	3	178	3	180	124
-7tm_1	O00398|reviewed|Putative	2	259	52	304	123
-7tm_1	O13018|reviewed|Vertebrate	1	259	56	303	123
-7tm_1	O00421|reviewed|C-C	2	259	56	299	123
-7tm_1	O08530|reviewed|Sphingosine	1	259	62	310	122
-7tm_1	O02777|reviewed|Cannabinoid	1	259	133	396	122
-7tm_1	B3DM66|reviewed|G-protein	1	259	39	318	122
-7tm_1	O12948|reviewed|Red-sensitive	2	259	70	320	120
-7tm_1	B2RPY5|reviewed|G-protein	1	259	60	339	120
-7tm_1	A1A5S3|reviewed|N-arachidonyl	2	256	40	282	117
-7tm_1	B2GV46|reviewed|Free	2	259	28	271	114
-7tm_1	O02465|reviewed|Opsin-2|taxID:7130	1	259	70	332	112
-7tm_1	O02721|reviewed|Lutropin-choriogonadotropic	1	259	353	599	112
-7tm_1	F8VQN3|reviewed|12-(S)-hydroxy-5,8,10,14-eicosatetraenoic	1	259	31	281	111
-7tm_1	A6QLE7|reviewed|G-protein	1	259	57	316	108
-7tm_1	O02769|reviewed|Melatonin	42	259	4	214	106
-7tm_1	D4A4Q2|reviewed|G-protein	7	259	37	284	105
-7tm_1	C8YUV0|reviewed|Free	1	259	57	320	103
-7tm_1	B2ZHY2|reviewed|G-protein	1	259	47	343	102
-7tm_1	B4XF06|reviewed|G-protein	1	259	47	343	102
-7tm_1	O02300|reviewed|Nematocin	1	259	61	340	99
-7tm_1	O09047|reviewed|C3a	1	159	40	193	99
-7tm_1	O12000|reviewed|G-protein	2	259	51	304	89
-7tm_1	A6NFC9|reviewed|Putative	1	140	41	181	88
-7tm_1	G5EEB1|reviewed|FMRFamide	1	253	21	281	78
-7tm_1	D4A3U0|reviewed|G-protein	2	223	59	332	67
-7tm_1	A5D7K8|reviewed|Prostaglandin	17	259	59	322	65
-7tm_1	G5ECD9|reviewed|G-protein	2	259	37	272	63
-7tm_1	A0A2R9YJI3|reviewed|G-protein	2	204	88	289	61
-7tm_1	B3DH96|reviewed|Odorant	2	189	36	220	61
-7tm_1	O02781|reviewed|Melatonin	84	222	1	132	60
-7tm_1	A0A0R4IP11|reviewed|Olfactory	1	217	22	260	56
-7tm_1	A2ARI4|reviewed|Leucine-rich	2	259	556	800	54
-7tm_1	E7FE13|reviewed|Leucine-rich	2	259	544	799	48
-7tm_1	F1MT22|reviewed|Leucine-rich	2	259	575	819	44
-7tm_1	E9Q4J9|reviewed|Adhesion	3	216	399	598	34
-7tm_1	O97148|reviewed|G-protein	3	216	230	437	31
-7tm_1	P70555|reviewed|Parathyroid	56	252	232	414	27
-7tm_1	O60241|reviewed|Adhesion	31	182	970	1100	26
-7tm_1	B4GD14|reviewed|Latrophilin	8	221	792	984	25
-7tm_1	Q292N4|reviewed|Latrophilin	8	221	801	993	25
+7tm_1	O08858|reviewed|Somatostatin	1	259	54	302	189	3.660E-55
+7tm_1	F1MV99|reviewed|Somatostatin	1	259	58	305	187	1.281E-54
+7tm_1	A0T2N3|reviewed|Apelin	1	259	51	315	182	7.499E-53
+7tm_1	O02824|reviewed|Alpha-1A	1	259	43	325	176	8.188E-51
+7tm_1	C3ZQF9|reviewed|QRFP-like	1	259	64	325	175	2.093E-50
+7tm_1	O02666|reviewed|Alpha-1D	1	259	118	406	174	5.347E-50
+7tm_1	F1R332|reviewed|Galanin	1	259	35	285	170	8.914E-49
+7tm_1	O02813|reviewed|Neuropeptide	1	258	56	317	170	1.218E-48
+7tm_1	O08892|reviewed|5-hydroxytryptamine	2	259	66	367	169	1.666E-48
+7tm_1	O08556|reviewed|C-C	1	259	49	298	169	3.112E-48
+7tm_1	O08565|reviewed|C-X-C	1	259	52	298	168	4.253E-48
+7tm_1	O02835|reviewed|Neuropeptide	1	258	57	318	168	4.253E-48
+7tm_1	E7F7V7|reviewed|Galanin	1	259	43	293	166	2.028E-47
+7tm_1	G3M4F8|reviewed|Octopamine	1	259	54	335	165	5.178E-47
+7tm_1	D4A7K7|reviewed|G-protein	1	259	44	303	162	4.608E-46
+7tm_1	O08726|reviewed|Galanin	1	259	42	291	161	1.176E-45
+7tm_1	O08786|reviewed|Cholecystokinin	1	259	58	377	161	1.607E-45
+7tm_1	A6QNL7|reviewed|CX3C	1	259	49	293	160	2.195E-45
+7tm_1	E9QJ73|reviewed|C-X-C	1	259	60	317	158	1.045E-44
+7tm_1	O02662|reviewed|Beta-3	1	259	54	345	158	1.428E-44
+7tm_1	A7YY44|reviewed|Proteinase-activated	2	259	122	372	158	1.951E-44
+7tm_1	F5HF62|reviewed|Envelope	1	259	50	290	156	6.794E-44
+7tm_1	O08890|reviewed|5-hydroxytryptamine	2	259	41	346	155	1.268E-43
+7tm_1	B2ZI34|reviewed|Neuromedin-B	1	258	60	322	155	1.732E-43
+7tm_1	O08725|reviewed|Growth	1	259	59	320	153	6.028E-43
+7tm_1	O02836|reviewed|Neuropeptide	1	259	68	325	152	2.098E-42
+7tm_1	O13076|reviewed|Adenosine	1	259	22	289	151	3.913E-42
+7tm_1	A5A4K9|reviewed|Growth	1	259	60	322	151	5.343E-42
+7tm_1	A5A4L1|reviewed|Growth	1	259	60	322	150	7.297E-42
+7tm_1	O00254|reviewed|Proteinase-activated	2	259	112	357	150	9.965E-42
+7tm_1	A5PLE7|reviewed|G-protein	1	259	44	302	149	1.858E-41
+7tm_1	O02213|reviewed|Tyramine	1	259	74	422	148	3.465E-41
+7tm_1	G4WMX4|reviewed|RYamide	1	259	47	309	148	4.731E-41
+7tm_1	O00590|reviewed|Atypical	1	259	63	311	147	6.460E-41
+7tm_1	B1PHQ8|reviewed|Chemerin-like	1	259	53	311	145	5.712E-40
+7tm_1	O00574|reviewed|C-X-C	1	259	48	287	144	7.798E-40
+7tm_1	A1ZAX0|reviewed|Neuropeptide	1	258	98	364	144	7.798E-40
+7tm_1	O09027|reviewed|Atypical	1	259	62	311	144	1.064E-39
+7tm_1	B5X337|reviewed|G-protein	1	259	54	312	143	1.453E-39
+7tm_1	O08707|reviewed|Atypical	1	259	62	310	143	1.453E-39
+7tm_1	O02667|reviewed|Adenosine	1	259	30	282	143	1.984E-39
+7tm_1	B9VR26|reviewed|Chemerin-like	1	259	52	310	143	2.708E-39
+7tm_1	O08675|reviewed|Proteinase-activated	2	259	111	356	143	2.708E-39
+7tm_1	O02464|reviewed|Opsin-1|taxID:7130	1	259	71	332	143	2.708E-39
+7tm_1	B0UXR0|reviewed|G-protein	1	259	41	300	141	1.283E-38
+7tm_1	F5HDK1|reviewed|Envelope	2	259	50	295	139	3.260E-38
+7tm_1	O00155|reviewed|Probable	1	259	56	306	138	1.543E-37
+7tm_1	B3G515|reviewed|G-protein	1	259	61	308	137	2.105E-37
+7tm_1	A4FUQ5|reviewed|Formyl	1	259	43	296	134	1.852E-36
+7tm_1	A0A287A2K5|reviewed|Gastrin/cholecystokinin	1	259	69	394	134	2.526E-36
+7tm_1	O08790|reviewed|Formyl	1	259	43	301	133	4.701E-36
+7tm_1	O01668|reviewed|Opsin	1	259	64	326	133	4.701E-36
+7tm_1	B0F9W3|reviewed|G-protein	1	259	61	308	132	8.746E-36
+7tm_1	F7EQ49|reviewed|G-protein	1	259	76	323	131	2.219E-35
+7tm_1	E7EM37|reviewed|Dopamine	1	194	54	238	129	1.046E-34
+7tm_1	O00270|reviewed|12-(S)-hydroxy-5,8,10,14-eicosatetraenoic	1	259	31	281	128	1.946E-34
+7tm_1	B0V1P1|reviewed|Melanocortin	1	259	58	299	127	6.722E-34
+7tm_1	A0A2L0VBG2|reviewed|Adipokinetic	1	259	123	392	127	6.722E-34
+7tm_1	O01670|reviewed|Octopamine	1	199	98	293	126	9.164E-34
+7tm_1	O08878|reviewed|G-protein	1	259	76	323	126	1.249E-33
+7tm_1	O02664|reviewed|D(1A)	3	178	3	180	124	8.011E-33
+7tm_1	O00398|reviewed|Putative	2	259	52	304	123	1.092E-32
+7tm_1	O13018|reviewed|Vertebrate	1	259	56	303	123	1.488E-32
+7tm_1	O00421|reviewed|C-C	2	259	56	299	123	2.028E-32
+7tm_1	O08530|reviewed|Sphingosine	1	259	62	310	122	3.765E-32
+7tm_1	O02777|reviewed|Cannabinoid	1	259	133	396	122	3.765E-32
+7tm_1	B3DM66|reviewed|G-protein	1	259	39	318	122	3.765E-32
+7tm_1	O12948|reviewed|Red-sensitive	2	259	70	320	120	1.297E-31
+7tm_1	B2RPY5|reviewed|G-protein	1	259	60	339	120	1.297E-31
+7tm_1	A1A5S3|reviewed|N-arachidonyl	2	256	40	282	117	2.093E-30
+7tm_1	B2GV46|reviewed|Free	2	259	28	271	114	1.334E-29
+7tm_1	O02465|reviewed|Opsin-2|taxID:7130	1	259	70	332	112	6.235E-29
+7tm_1	O02721|reviewed|Lutropin-choriogonadotropic	1	259	353	599	112	6.235E-29
+7tm_1	F8VQN3|reviewed|12-(S)-hydroxy-5,8,10,14-eicosatetraenoic	1	259	31	281	111	1.572E-28
+7tm_1	A6QLE7|reviewed|G-protein	1	259	57	316	108	2.510E-27
+7tm_1	O02769|reviewed|Melatonin	42	259	4	214	106	6.313E-27
+7tm_1	D4A4Q2|reviewed|G-protein	7	259	37	284	105	2.158E-26
+7tm_1	C8YUV0|reviewed|Free	1	259	57	320	103	7.370E-26
+7tm_1	B2ZHY2|reviewed|G-protein	1	259	47	343	102	1.361E-25
+7tm_1	B4XF06|reviewed|G-protein	1	259	47	343	102	2.514E-25
+7tm_1	O02300|reviewed|Nematocin	1	259	61	340	99	1.581E-24
+7tm_1	O09047|reviewed|C3a	1	159	40	193	99	2.147E-24
+7tm_1	O12000|reviewed|G-protein	2	259	51	304	89	5.981E-21
+7tm_1	A6NFC9|reviewed|Putative	1	140	41	181	88	8.105E-21
+7tm_1	G5EEB1|reviewed|FMRFamide	1	253	21	281	78	2.849E-17
+7tm_1	D4A3U0|reviewed|G-protein	2	223	59	332	67	9.121E-14
+7tm_1	A5D7K8|reviewed|Prostaglandin	17	259	59	322	65	2.987E-13
+7tm_1	G5ECD9|reviewed|G-protein	2	259	37	272	63	1.311E-12
+7tm_1	A0A2R9YJI3|reviewed|G-protein	2	204	88	289	61	5.729E-12
+7tm_1	B3DH96|reviewed|Odorant	2	189	36	220	61	1.032E-11
+7tm_1	O02781|reviewed|Melatonin	84	222	1	132	60	1.385E-11
+7tm_1	B0BLW3|reviewed|Leucine-rich	2	259	559	803	59	3.343E-11
+7tm_1	A0A0R4IP11|reviewed|Olfactory	1	217	22	260	56	2.596E-10
+7tm_1	A2ARI4|reviewed|Leucine-rich	2	259	556	800	54	1.116E-09
+7tm_1	F7D3V9|reviewed|Leucine-rich	2	259	571	815	48	8.637E-08
+7tm_1	F1MT22|reviewed|Leucine-rich	2	259	575	819	44	2.723E-06
+7tm_1	D4A3T6|reviewed|Adhesion	3	216	399	598	35	1.443E-03
+7tm_1	B7ZCC9|reviewed|Adhesion	4	225	2712	2919	34	1.916E-03
+7tm_1	E9Q4J9|reviewed|Adhesion	3	216	399	598	34	2.545E-03
+7tm_1	P41588|reviewed|Vasoactive	7	222	145	346	33	4.486E-03
+7tm_1	P41587|reviewed|Vasoactive	7	222	146	347	33	4.486E-03
+7tm_1	G5E8Q8|reviewed|Adhesion	3	216	1032	1234	33	4.486E-03
+7tm_1	O97148|reviewed|G-protein	3	216	230	437	31	1.848E-02
+7tm_1	P83120|reviewed|G-protein	3	216	230	437	31	1.848E-02
+7tm_1	P35000|reviewed|Vasoactive	7	222	145	346	31	2.453E-02
+7tm_1	P41586|reviewed|Pituitary	6	175	172	333	31	2.453E-02
+7tm_1	Q29627|reviewed|Pituitary	6	175	189	350	31	2.453E-02
+7tm_2	P97751|reviewed|Vasoactive	1	249	140	385	246	4.202E-75
+7tm_2	P30083|reviewed|Vasoactive	1	249	140	385	246	5.755E-75
+7tm_2	P32241|reviewed|Vasoactive	1	249	139	383	243	7.118E-74
+7tm_2	Q28992|reviewed|Vasoactive	1	249	140	384	242	1.335E-73
+7tm_2	P41586|reviewed|Pituitary	1	249	150	395	242	1.335E-73
+7tm_2	O46502|reviewed|Secretin	3	249	137	379	236	1.490E-71
+7tm_2	P23811|reviewed|Secretin	3	249	141	383	235	2.793E-71
+7tm_2	P47872|reviewed|Secretin	3	249	141	383	231	4.725E-70
+7tm_2	P70205|reviewed|Pituitary	1	249	150	423	227	2.051E-68
+7tm_2	Q29627|reviewed|Pituitary	1	249	167	440	227	2.051E-68
+7tm_2	P41587|reviewed|Vasoactive	1	249	123	370	222	1.218E-66
+7tm_2	P32215|reviewed|Pituitary	1	249	149	450	215	2.536E-64
+7tm_2	P50133|reviewed|Parathyroid	1	249	180	449	214	6.505E-64
+7tm_2	P35000|reviewed|Vasoactive	1	249	122	369	213	1.219E-63
+7tm_2	P41588|reviewed|Vasoactive	1	249	122	369	213	1.669E-63
+7tm_2	Q1LZF7|reviewed|Parathyroid	1	249	184	453	213	1.669E-63
+7tm_2	P25107|reviewed|Parathyroid	1	249	181	448	212	2.284E-63
+7tm_2	Q03431|reviewed|Parathyroid	1	249	184	454	211	4.279E-63
+7tm_2	O95490|reviewed|Adhesion	4	249	847	1079	208	7.216E-62
+7tm_2	P25961|reviewed|Parathyroid	1	249	184	454	207	1.352E-61
+7tm_2	P41593|reviewed|Parathyroid	1	249	184	454	207	1.352E-61
+7tm_2	P49190|reviewed|Parathyroid	1	249	141	408	206	2.532E-61
+7tm_2	P32082|reviewed|Growth	1	249	126	371	206	3.466E-61
+7tm_2	P48960|reviewed|Adhesion	3	249	546	781	206	3.466E-61
+7tm_2	Q02643|reviewed|Growth	1	249	126	371	205	4.744E-61
+7tm_2	O35659|reviewed|Glucagon-like	3	249	143	397	203	4.267E-60
+7tm_2	P32301|reviewed|Glucagon-like	3	249	143	397	202	5.840E-60
+7tm_2	O97827|reviewed|Adhesion	4	249	945	1186	202	7.992E-60
+7tm_2	P34999|reviewed|Growth	1	249	126	371	201	2.049E-59
+7tm_2	O08893|reviewed|Calcitonin	1	249	145	386	200	2.803E-59
+7tm_2	O97831|reviewed|Adhesion	4	249	859	1091	200	3.837E-59
+7tm_2	O88917|reviewed|Adhesion	4	249	859	1091	200	3.837E-59
+7tm_2	P43219|reviewed|Gastric	3	249	133	384	199	5.250E-59
+7tm_2	O94910|reviewed|Adhesion	4	249	860	1092	199	5.250E-59
+7tm_2	Q0P543|reviewed|Gastric	3	249	132	383	199	7.185E-59
+7tm_2	P48546|reviewed|Gastric	3	249	136	387	199	7.185E-59
+7tm_2	P43220|reviewed|Glucagon-like	4	249	144	397	199	9.832E-59
+7tm_2	P30988|reviewed|Calcitonin	1	249	145	386	199	9.832E-59
+7tm_2	P30082|reviewed|Glucagon	1	249	139	396	199	9.832E-59
+7tm_2	P70555|reviewed|Parathyroid	1	249	139	405	198	2.520E-58
+7tm_2	O95838|reviewed|Glucagon-like	4	249	178	431	198	2.520E-58
+7tm_2	O97817|reviewed|Adhesion	4	249	851	1098	197	3.448E-58
+7tm_2	P43218|reviewed|Gastric	3	249	133	384	196	8.835E-58
+7tm_2	P35347|reviewed|Corticotropin-releasing	6	249	121	358	196	1.209E-57
+7tm_2	P34998|reviewed|Corticotropin-releasing	1	249	116	358	195	2.264E-57
+7tm_2	P35353|reviewed|Corticotropin-releasing	1	249	116	358	195	2.264E-57
+7tm_2	P47871|reviewed|Glucagon	1	249	138	395	195	2.264E-57
+7tm_2	Q14246|reviewed|Adhesion	3	249	601	839	195	2.264E-57
+7tm_2	P79222|reviewed|Calcitonin	1	249	145	386	194	3.098E-57
+7tm_2	Q0P4Y4|reviewed|Calcitonin	1	249	148	389	194	4.239E-57
+7tm_2	O62772|reviewed|Corticotropin-releasing	6	249	121	358	193	7.936E-57
+7tm_2	Q16602|reviewed|Calcitonin	1	249	138	379	192	1.486E-56
+7tm_2	A0A2Z2U4G9|reviewed|Glucagon	1	249	138	395	192	2.033E-56
+7tm_2	O88923|reviewed|Adhesion	4	249	851	1107	192	2.782E-56
+7tm_2	O42602|reviewed|Corticotropin-releasing	6	249	121	358	189	1.825E-55
+7tm_2	A6QP74|reviewed|Calcitonin	1	249	139	380	189	2.497E-55
+7tm_2	P32214|reviewed|Calcitonin	1	249	145	423	188	6.393E-55
+7tm_2	Q02644|reviewed|Growth	1	249	126	412	185	4.192E-54
+7tm_2	P47866|reviewed|Corticotropin-releasing	6	249	118	354	184	7.845E-54
+7tm_2	O42603|reviewed|Corticotropin-releasing	6	249	120	356	183	2.747E-53
+7tm_2	Q13324|reviewed|Corticotropin-releasing	6	249	118	354	181	9.619E-53
+7tm_2	P25117|reviewed|Calcitonin	4	249	149	403	178	1.612E-51
+7tm_2	O35161|reviewed|Cadherin	4	249	2483	2711	177	3.016E-51
+7tm_2	G5ECX0|reviewed|Latrophilin-like	1	249	894	1128	171	3.301E-49
+7tm_2	O88278|reviewed|Cadherin	4	248	2537	2764	169	2.158E-48
+7tm_2	A6QLU6|reviewed|Adhesion	4	249	594	829	168	2.950E-48
+7tm_2	Q2Q421|reviewed|Adhesion	4	249	543	780	167	1.031E-47
+7tm_2	O14514|reviewed|Adhesion	1	249	944	1179	162	4.395E-46
+7tm_2	C0HL12|reviewed|Adhesion	6	249	945	1175	161	8.212E-46
+7tm_2	Q3UHD1|reviewed|Adhesion	6	249	949	1179	161	8.212E-46
+7tm_2	Q09460|reviewed|Calcitonin	1	249	164	424	160	2.867E-45
+7tm_2	Q2Q426|reviewed|Adhesion	4	249	529	766	157	1.869E-44
+7tm_2	P35464|reviewed|Diuretic	7	248	89	338	156	6.520E-44
+7tm_2	Q16983|reviewed|Diuretic	10	248	139	380	156	6.520E-44
+7tm_2	O60241|reviewed|Adhesion	3	249	931	1197	149	1.315E-41
+7tm_2	G5EDW2|reviewed|Latrophilin-like	4	249	551	787	144	5.550E-40
+7tm_2	O60242|reviewed|Adhesion	6	249	879	1142	144	5.550E-40
+7tm_2	B7ZCC9|reviewed|Adhesion	4	249	2693	2931	139	2.335E-38
+7tm_2	C6KFA3|reviewed|Adhesion	4	249	851	1098	135	7.168E-37
+7tm_2	P30650|reviewed|G-protein	12	225	230	446	109	7.511E-28
+7tm_2	G5E8Q8|reviewed|Adhesion	4	249	1014	1263	104	4.129E-26
+7tm_2	Q3V3Z3|reviewed|Adhesion	4	249	244	494	101	2.615E-25
+7tm_2	E9Q4J9|reviewed|Adhesion	4	246	381	624	99	1.216E-24
+7tm_2	D4A3T6|reviewed|Adhesion	4	246	381	624	98	2.247E-24
+7tm_2	Q50DM6|reviewed|Adhesion	4	249	403	647	94	6.551E-23
+7tm_2	Q50DM5|reviewed|Adhesion	4	249	403	647	91	5.576E-22
+7tm_2	B3MFV7|reviewed|Latrophilin	3	248	763	1010	73	8.659E-16
+7tm_2	B4KMZ1|reviewed|Latrophilin	3	248	755	1002	73	8.659E-16
+7tm_2	B4P3A0|reviewed|Latrophilin	3	248	765	1012	72	2.132E-15
+7tm_2	B4HS00|reviewed|Latrophilin	3	248	751	998	71	2.878E-15
+7tm_2	A1Z7G7|reviewed|Latrophilin	3	248	751	998	71	2.878E-15
+7tm_2	B3N8M1|reviewed|Latrophilin	3	248	765	1012	71	2.878E-15
+7tm_2	B4GD14|reviewed|Latrophilin	3	248	763	1010	71	3.885E-15
+7tm_2	Q292N4|reviewed|Latrophilin	3	248	772	1019	71	3.885E-15
+7tm_2	B4LNA8|reviewed|Latrophilin	3	245	769	1010	71	3.885E-15
+7tm_2	B4J780|reviewed|Latrophilin	3	248	784	1032	68	2.342E-14
+7tm_2	P83120|reviewed|G-protein	9	249	219	469	68	4.256E-14
+7tm_2	O97148|reviewed|G-protein	9	249	219	469	67	5.737E-14
+7tm_2	E7FBY6|reviewed|Adhesion	6	186	743	925	53	2.383E-09
+7tm_2	G5EDK5|reviewed|Cadherin	17	224	2237	2423	47	1.865E-07
+7tm_3	P41180|reviewed|Extracellular	1	249	606	854	230	1.730E-69
+7tm_3	O62714|reviewed|Extracellular	1	249	606	854	229	2.369E-69
+7tm_3	P35384|reviewed|Extracellular	1	249	607	855	228	6.080E-69
+7tm_3	P48442|reviewed|Extracellular	1	249	606	854	228	1.140E-68
+7tm_3	E9Q6I0|reviewed|Vomeronasal	1	250	579	828	214	3.614E-64
+7tm_3	Q6TAC4|reviewed|Vomeronasal	1	250	587	836	211	4.454E-63
+7tm_3	P31422|reviewed|Metabotropic	1	250	570	821	209	4.009E-62
+7tm_3	Q14416|reviewed|Metabotropic	1	250	561	812	205	4.936E-61
+7tm_3	Q14BI2|reviewed|Metabotropic	1	250	561	812	205	6.756E-61
+7tm_3	P31421|reviewed|Metabotropic	1	250	561	812	205	9.246E-61
+7tm_3	Q1ZZH1|reviewed|Metabotropic	1	250	570	821	205	9.246E-61
+7tm_3	Q14832|reviewed|Metabotropic	1	250	570	821	204	1.265E-60
+7tm_3	Q5RAL3|reviewed|Metabotropic	1	250	570	821	204	1.732E-60
+7tm_3	Q70VB1|reviewed|G-protein	1	250	587	834	203	4.439E-60
+7tm_3	Q8K4Z6|reviewed|G-protein	1	250	587	834	202	6.075E-60
+7tm_3	Q5U9X3|reviewed|G-protein	2	250	560	804	200	2.916E-59
+7tm_3	P91685|reviewed|Metabotropic	1	250	620	869	198	1.399E-58
+7tm_3	P23385|reviewed|Metabotropic	1	250	586	833	198	1.915E-58
+7tm_3	P97772|reviewed|Metabotropic	1	250	586	833	198	1.915E-58
+7tm_3	Q5T6X5|reviewed|G-protein	1	250	587	832	197	4.907E-58
+7tm_3	Q13255|reviewed|Metabotropic	1	250	586	833	197	4.907E-58
+7tm_3	P31424|reviewed|Metabotropic	1	250	572	819	194	4.407E-57
+7tm_3	Q3UVX5|reviewed|Metabotropic	1	250	572	819	194	4.407E-57
+7tm_3	P41594|reviewed|Metabotropic	1	250	573	820	194	4.407E-57
+7tm_3	Q09630|reviewed|Probable	1	250	675	922	192	2.891E-56
+7tm_3	O70410|reviewed|Vomeronasal	1	250	614	862	188	6.644E-55
+7tm_3	O00222|reviewed|Metabotropic	1	250	577	836	185	5.958E-54
+7tm_3	P47743|reviewed|Metabotropic	1	250	577	836	185	5.958E-54
+7tm_3	P70579|reviewed|Metabotropic	1	250	577	836	185	5.958E-54
+7tm_3	P35400|reviewed|Metabotropic	1	250	584	843	185	5.958E-54
+7tm_3	Q14831|reviewed|Metabotropic	1	250	584	843	185	5.958E-54
+7tm_3	Q68ED2|reviewed|Metabotropic	1	250	584	843	185	5.958E-54
+7tm_3	Q5RDQ8|reviewed|Metabotropic	1	250	584	843	185	5.958E-54
+7tm_3	O15303|reviewed|Metabotropic	1	250	579	838	183	2.854E-53
+7tm_3	Q863I4|reviewed|Metabotropic	1	250	570	829	181	9.992E-53
+7tm_3	P35349|reviewed|Metabotropic	1	250	573	832	181	9.992E-53
+7tm_3	Q68EF4|reviewed|Metabotropic	1	250	581	840	181	9.992E-53
+7tm_3	P31423|reviewed|Metabotropic	1	250	581	840	181	1.367E-52
+7tm_3	Q1ZZH0|reviewed|Metabotropic	1	250	581	840	180	2.557E-52
+7tm_3	Q5NCH9|reviewed|Metabotropic	1	250	573	832	180	3.497E-52
+7tm_3	Q14833|reviewed|Metabotropic	1	250	581	840	180	3.497E-52
+7tm_3	E1BPQ3|reviewed|G-protein	5	250	565	801	171	3.426E-49
+7tm_3	O75899|reviewed|Gamma-aminobutyric	2	250	476	742	166	2.734E-47
+7tm_3	O88871|reviewed|Gamma-aminobutyric	2	250	475	741	165	3.737E-47
+7tm_3	Q80T41|reviewed|Gamma-aminobutyric	2	250	475	741	165	3.737E-47
+7tm_3	Q54SW3|reviewed|Metabotropic	2	248	364	614	158	1.037E-44
+7tm_3	A3QP08|reviewed|Taste	1	250	554	805	156	3.618E-44
+7tm_3	A3QNZ8|reviewed|Taste	1	250	559	810	156	3.618E-44
+7tm_3	A3QNZ9|reviewed|Taste	1	250	559	810	156	3.618E-44
+7tm_3	Q8TE23|reviewed|Taste	1	250	559	810	156	3.618E-44
+7tm_3	Q49HI0|reviewed|Taste	1	250	558	807	156	6.756E-44
+7tm_3	A3QP01|reviewed|Taste	1	250	559	810	154	1.724E-43
+7tm_3	A3QP07|reviewed|Taste	1	250	559	810	154	1.724E-43
+7tm_3	Q75JT4|reviewed|Metabotropic	1	248	373	624	154	3.219E-43
+7tm_3	Q925I4|reviewed|Taste	1	250	563	814	153	6.010E-43
+7tm_3	A3QP00|reviewed|Taste	1	250	559	810	153	8.212E-43
+7tm_3	Q55AP1|reviewed|Metabotropic	2	248	379	629	149	9.969E-42
+7tm_3	Q86HH3|reviewed|Metabotropic	2	248	377	627	149	1.362E-41
+7tm_3	G5ECB2|reviewed|Gamma-aminobutyric	3	250	436	698	149	1.860E-41
+7tm_3	Q54ET0|reviewed|Metabotropic	3	250	431	676	147	6.478E-41
+7tm_3	A3QP09|reviewed|Taste	1	250	554	805	147	8.849E-41
+7tm_3	Q7RTX1|reviewed|Taste	1	250	560	810	146	1.209E-40
+7tm_3	Q54L53|reviewed|Metabotropic	4	250	386	636	145	4.206E-40
+7tm_3	Q54LG8|reviewed|Metabotropic	1	250	377	630	144	7.845E-40
+7tm_3	Q54SH7|reviewed|Metabotropic	3	250	386	637	143	1.998E-39
+7tm_3	Q54SH8|reviewed|Metabotropic	3	250	387	638	138	6.146E-38
+7tm_3	Q75JP4|reviewed|Metabotropic	2	250	385	637	138	8.390E-38
+7tm_3	Q923K1|reviewed|Taste	1	250	567	817	136	2.914E-37
+7tm_3	Q1ZXQ7|reviewed|Metabotropic	3	250	378	629	135	1.011E-36
+7tm_3	Q55AP3|reviewed|Metabotropic	2	248	388	645	134	1.380E-36
+7tm_3	Q49HH9|reviewed|Taste	1	250	560	810	134	1.884E-36
+7tm_3	Q717C2|reviewed|Taste	1	250	562	812	134	1.884E-36
+7tm_3	Q717C1|reviewed|Taste	1	250	562	812	134	2.571E-36
+7tm_3	Q7RTX0|reviewed|Taste	1	250	562	812	133	4.789E-36
+7tm_3	Q54F54|reviewed|Metabotropic	1	250	689	941	130	5.756E-35
+7tm_3	E9PY61|reviewed|G-protein	6	250	379	629	129	1.071E-34
+7tm_3	Q925D8|reviewed|Taste	1	250	567	817	128	1.994E-34
+7tm_3	Q49KI5|reviewed|Taste	1	250	565	815	128	1.994E-34
+7tm_3	Q5T848|reviewed|Metabotropic	7	250	416	665	124	3.258E-33
+7tm_3	Q6PRD1|reviewed|Probable	7	250	380	629	124	4.443E-33
+7tm_3	D4A6L0|reviewed|Metabotropic	7	250	416	665	124	6.059E-33
+7tm_3	E1BBQ2|reviewed|Metabotropic	7	250	416	665	124	6.059E-33
+7tm_3	Q8C419|reviewed|Metabotropic	7	250	416	665	123	1.536E-32
+7tm_3	Q8K451|reviewed|Probable	10	250	52	310	120	9.865E-32
+7tm_3	Q54QG7|reviewed|Metabotropic	3	250	393	641	120	9.865E-32
+7tm_3	Q6PCP7|reviewed|Probable	10	250	52	310	120	1.345E-31
+7tm_3	Q8NFN8|reviewed|Probable	2	250	44	310	117	1.175E-30
+7tm_3	Q54K11|reviewed|Metabotropic	4	250	1145	1394	113	1.901E-29
+7tm_3	H2L0Q3|reviewed|Gamma-aminobutyric	1	250	442	763	111	1.652E-28
+7tm_3	Q923Z0|reviewed|G-protein	1	250	49	290	106	6.691E-27
+7tm_3	Q54K09|reviewed|Metabotropic	1	250	727	978	99	1.249E-24
+7tm_3	Q8BHL4|reviewed|Retinoic	1	250	23	265	96	1.069E-23
+7tm_3	Q8K3J9|reviewed|G-protein	1	250	42	297	95	2.682E-23
+7tm_3	Q54U89|reviewed|Metabotropic	10	248	368	616	95	2.682E-23
+7tm_3	Q2YDG0|reviewed|G-protein	1	250	43	299	94	4.948E-23
+7tm_3	Q3KRC4|reviewed|G-protein	1	250	42	297	94	6.721E-23
+7tm_3	Q8NFJ5|reviewed|Retinoic	1	250	21	263	87	1.639E-20
+7tm_3	Q24738|reviewed|Protein	5	250	525	772	76	7.947E-17
+7tm_3	P22815|reviewed|Protein	5	250	528	775	76	7.947E-17
+7tm_3	P34352|reviewed|Uncharacterized	9	238	691	904	72	1.192E-15
+7tm_3	C0HL12|reviewed|Adhesion	11	102	945	1037	31	2.324E-02
+7tm_3	Q3UHD1|reviewed|Adhesion	11	102	949	1041	31	2.324E-02
+7tm_3	O14514|reviewed|Adhesion	11	102	949	1041	31	2.324E-02
+AAA	A1URA3|reviewed|ATP-dependent	1	130	192	324	125	1.899E-35
+AAA	A0PXM8|reviewed|ATP-dependent	1	130	204	336	124	3.571E-35
+AAA	A0L4S0|reviewed|ATP-dependent	1	130	190	322	123	1.732E-34
+AAA	A4G0S4|reviewed|Proteasome-activating	1	129	185	316	121	6.123E-34
+AAA	A1AT11|reviewed|ATP-dependent	1	130	210	342	121	6.123E-34
+AAA	A0A061IR73|reviewed|Peroxisomal	1	130	740	871	121	6.123E-34
+AAA	A3CV35|reviewed|Proteasome-activating	1	130	190	322	120	1.579E-33
+AAA	A0LR74|reviewed|ATP-dependent	1	130	215	348	118	5.583E-33
+AAA	A1TZE0|reviewed|ATP-dependent	1	130	222	354	118	7.656E-33
+AAA	A0LN68|reviewed|ATP-dependent	1	130	223	355	117	1.050E-32
+AAA	A2ZVG7|reviewed|ATP-dependent	1	130	364	492	113	4.640E-31
+AAA	A2SHH9|reviewed|ATP-dependent	1	130	194	327	111	1.196E-30
+AAA	A2VDN5|reviewed|Spastin|taxID:9913	1	129	376	504	111	1.640E-30
+AAA	A4IHT0|reviewed|Fidgetin-like	1	130	419	548	110	4.229E-30
+AAA	A0JMA9|reviewed|Katanin	1	130	294	425	105	2.560E-28
+AAA	A0A7N9VSG0|reviewed|ATPase	1	130	230	362	102	2.331E-27
+AAA	A1SK07|reviewed|Proteasome-associated	1	130	266	412	96	3.630E-25
+AAA	A0LU46|reviewed|Proteasome-associated	1	130	264	411	95	4.977E-25
+AAA	A0PQT9|reviewed|Proteasome-associated	1	130	289	438	94	9.353E-25
+AAA	A0QFB2|reviewed|Proteasome-associated	1	130	289	438	94	9.353E-25
+AAA	A1KKF8|reviewed|Proteasome-associated	1	130	289	438	94	9.353E-25
+AAA	A0QZ54|reviewed|Proteasome-associated	1	130	293	442	94	9.353E-25
+AAA	A1TAQ3|reviewed|Proteasome-associated	1	130	295	444	94	9.353E-25
+AAA	A1UHT0|reviewed|Proteasome-associated	1	130	295	444	94	9.353E-25
+AAA	A3Q196|reviewed|Proteasome-associated	1	130	295	444	94	9.353E-25
+AAA	A4FBX6|reviewed|Proteasome-associated	1	130	277	426	94	1.758E-24
+AAA	A1A0U4|reviewed|AAA	1	130	233	374	93	3.303E-24
+AAA	A0JWY3|reviewed|Proteasome-associated	1	129	275	421	93	4.527E-24
+AAA	A1R6Q4|reviewed|Proteasome-associated	1	129	283	429	93	4.527E-24
+AAA	A2XUN8|reviewed|Pachytene	1	130	209	354	74	1.222E-17
+AAA	A3LUF7|reviewed|Lon	1	119	663	800	72	4.300E-17
+AAA	A0RJ87|reviewed|Lon	1	126	370	507	71	1.105E-16
+AAA	A0LEE9|reviewed|Lon	1	126	360	497	70	2.838E-16
+AAA	A0QNI9|reviewed|ESX-1	1	130	331	465	68	9.977E-16
+AAA	A3M072|reviewed|Lon	1	126	554	691	68	9.977E-16
+AAA	A0A8I6AGW3|reviewed|Fidgetin-like	1	129	427	550	67	3.506E-15
+AAA	A0L516|reviewed|Lon	1	130	391	532	65	1.686E-14
+AAA	A2RAF6|reviewed|Lon	1	126	480	618	65	1.686E-14
+AAA	A2QCJ2|reviewed|Lon	1	124	605	740	64	2.308E-14
+AAA	A0LG61|reviewed|Lon	1	126	358	495	63	1.108E-13
+AAA	A2YQ56|reviewed|Lon	1	126	464	601	63	1.108E-13
+AAA	A0QQ38|reviewed|ESX-3	1	130	361	493	58	4.766E-12
+AAA	A2BL93|reviewed|Replication	2	74	48	120	54	7.960E-11
+AAA	A3DNV8|reviewed|Replication	2	112	47	144	53	1.487E-10
+AAA	A4FZL6|reviewed|Replication	1	122	42	148	52	5.185E-10
+AAA	A2T308|reviewed|Protein	1	129	1651	1794	51	7.084E-10
+AAA	A3CTR4|reviewed|Replication	1	74	39	112	51	9.677E-10
+AAA	A3MS27|reviewed|Replication	1	119	59	163	50	2.466E-09
+AAA	A2SQR6|reviewed|Replication	1	87	39	125	49	4.598E-09
+AAA	A2SQT3|reviewed|Replication	1	130	42	161	48	1.170E-08
+AAA	A1RWU6|reviewed|Replication	2	124	51	161	48	1.170E-08
+AAA	A3MS28|reviewed|Replication	1	130	40	159	48	1.597E-08
+AAA	A0B6D7|reviewed|Replication	1	119	43	148	47	2.179E-08
+AAA	A4FZ74|reviewed|Replication	1	130	39	158	47	2.974E-08
+AAA	A1RSA2|reviewed|Replication	1	130	40	159	46	5.535E-08
+AAA	A3DNV9|reviewed|Replication	1	130	47	166	45	1.030E-07
+AAA	A1RSA3|reviewed|Replication	1	111	59	157	45	1.030E-07
+AAA	A1RV38|reviewed|Replication	1	118	40	148	44	2.611E-07
+AAA	A0R574|reviewed|ATP-dependent	3	76	214	299	44	2.611E-07
+AAA	A3CUX9|reviewed|Replication	1	130	42	161	42	1.672E-06
+AAA	A1RWU7|reviewed|Replication	1	130	40	159	40	4.220E-06
+AAA	A1S2P4|reviewed|ATP-dependent	1	89	53	136	40	5.745E-06
+AAA	A0L1J9|reviewed|ATP-dependent	1	89	53	136	38	1.968E-05
+AAA	A3N333|reviewed|ATP-dependent	1	89	52	135	37	4.947E-05
+AAA	A3Q9U8|reviewed|ATP-dependent	1	89	53	136	37	4.947E-05
+AAA	A1RP57|reviewed|ATP-dependent	1	89	53	136	37	4.947E-05
+AAA	A3D9C6|reviewed|ATP-dependent	1	89	53	136	37	4.947E-05
+AAA	A1AIA6|reviewed|ATP-dependent	1	89	53	136	37	4.947E-05
+AAA	A1UU56|reviewed|ATP-dependent	1	46	54	100	37	6.723E-05
+AAA	A0KQI8|reviewed|ATP-dependent	1	53	53	106	36	9.134E-05
+AAA	A1JI08|reviewed|ATP-dependent	1	53	53	106	36	9.134E-05
+AAA	A1SQW3|reviewed|ATP-dependent	1	46	53	99	36	9.134E-05
+AAA	A0Q6L9|reviewed|ATP-dependent	1	57	54	112	36	9.134E-05
+AAA	A4IY57|reviewed|ATP-dependent	1	57	54	112	36	9.134E-05
+AAA	A0KBG3|reviewed|ATP-dependent	1	91	53	138	36	1.241E-04
+AAA	A1WRK1|reviewed|ATP-dependent	1	57	53	107	36	1.685E-04
+AAA	A1K2I6|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A1V7K6|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A2S869|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A3MRR3|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A3N4H2|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A3NQ62|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A0L3K1|reviewed|ATP-dependent	1	46	53	99	36	1.685E-04
+AAA	A1TKC1|reviewed|ATP-dependent	1	89	53	136	35	2.287E-04
+AAA	A1TYU5|reviewed|ATP-dependent	1	46	53	99	35	2.287E-04
+AAA	A1WC16|reviewed|ATP-dependent	1	89	53	136	35	2.287E-04
+AAA	A4IM89|reviewed|ATP-dependent	1	46	54	100	35	2.287E-04
+AAA	A4J5Z5|reviewed|ATP-dependent	1	46	53	99	35	2.287E-04
+AAA	A1VZ21|reviewed|ATP-dependent	1	36	52	87	35	3.105E-04
+AAA	A1VDW3|reviewed|ATP-dependent	1	91	53	138	35	3.105E-04
+AAA	A0A379|reviewed|Protein	50	118	1725	1789	34	4.213E-04
+AAA	A2SPC3|reviewed|ORC1-type	1	130	63	223	34	5.715E-04
+AAA	A0AI82|reviewed|ATP-dependent	1	46	59	105	34	7.751E-04
+AAA	A1B5T0|reviewed|ATP-dependent	1	46	53	99	33	1.424E-03
+AAA	A3PG35|reviewed|ATP-dependent	1	46	53	99	33	1.930E-03
+AAA	A4GGE1|reviewed|Protein	1	118	1625	1781	32	2.614E-03
+AAA	A4GYV4|reviewed|Protein	50	118	1729	1793	31	4.793E-03
+AAA	A1XGT0|reviewed|Protein	50	118	1729	1793	31	6.486E-03
+AAA	A0ZZ78|reviewed|Protein	50	118	1740	1804	30	1.187E-02
+AAA	A1XFZ9|reviewed|Protein	50	118	1696	1760	30	1.604E-02

--- a/libnail/src/align/structs/alignment.rs
+++ b/libnail/src/align/structs/alignment.rs
@@ -58,6 +58,8 @@ pub struct DisplayStrings {
 pub struct Alignment {
     /// The name of the profile/model
     pub profile_name: Option<String>,
+    /// The accession of the profile/model
+    pub profile_accession: Option<String>,
     /// The name of the target sequence
     pub target_name: Option<String>,
     /// The boundaries of the alignment
@@ -297,6 +299,13 @@ impl<'a> AlignmentBuilder<'a> {
 
         Ok(Alignment {
             profile_name: self.profile.map(|profile| profile.name.clone()),
+            profile_accession: self.profile.and_then(|profile| {
+                if profile.accession.is_empty() {
+                    None
+                } else {
+                    Some(profile.accession.clone())
+                }
+            }),
             target_name: self.target.map(|target| target.name.clone()),
             boundaries,
             scores,

--- a/libnail/src/output/output_tabular.rs
+++ b/libnail/src/output/output_tabular.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 pub static BIT_P: OnceLock<usize> = OnceLock::new();
 pub static F32_P: OnceLock<usize> = OnceLock::new();
 pub static F64_P: OnceLock<usize> = OnceLock::new();
+pub static ACC: OnceLock<bool> = OnceLock::new();
 
 trait FieldString {
     fn field_string(&self) -> String;
@@ -49,7 +50,18 @@ impl Field {
     fn extract(&self, alignment: &Alignment) -> Option<String> {
         Some(match self {
             Field::Target => alignment.target_name.clone()?,
-            Field::Query => alignment.profile_name.clone()?,
+            Field::Query => {
+                if *ACC.get().unwrap_or(&false) {
+                    // prefer the accession, but fall back to the
+                    // name when the profile has no accession
+                    alignment
+                        .profile_accession
+                        .clone()
+                        .or_else(|| alignment.profile_name.clone())?
+                } else {
+                    alignment.profile_name.clone()?
+                }
+            }
             Field::TargetStart => alignment.boundaries.as_ref()?.target_start.to_string(),
             Field::TargetEnd => alignment.boundaries.as_ref()?.target_end.to_string(),
             Field::QueryStart => alignment.boundaries.as_ref()?.profile_start.to_string(),

--- a/nail/src/args.rs
+++ b/nail/src/args.rs
@@ -137,6 +137,12 @@ impl SearchArgs {
             }
         }
 
+        let use_accession =
+            *libnail::output::output_tabular::ACC.get_or_init(|| self.io_args.use_accession);
+        if use_accession != self.io_args.use_accession {
+            bail!("failed to set ACC")
+        }
+
         {
             if let Some(path) = &self.io_args.tbl_results_path {
                 match path.check_open(self.io_args.allow_overwrite) {
@@ -302,6 +308,10 @@ pub struct IoArgs {
     /// Allow nail to overwrite files
     #[arg(short = 'X', long = "allow-overwrite", default_value_t = false)]
     pub allow_overwrite: bool,
+
+    /// Use profile accessions instead of names in the output
+    #[arg(long = "acc", action)]
+    pub use_accession: bool,
 }
 
 #[derive(Args, Debug, Clone, Default)]


### PR DESCRIPTION
Hi, and thanks for creating `nail`!

This PR adds the `--acc` option, which mirrors `hmmsearch -acc`: when set, the query column report the profile accession (e.g. `PF00001.27`) instead of the profile name (e.g. `7tm_1`). Profiles without an accession fallback to the name.

I also re-created `fixtures/a.seed` with the 8th column (E-value) that `io/seeds.rs` expects:

https://github.com/TravisWheelerLab/nail/blob/e6388ba5f0c7a2258fb8aa016a79cef7398f2213/nail/src/io/seeds.rs#L39